### PR TITLE
Add several methods and changes

### DIFF
--- a/app/src/main/cpp/Detail_AR_Main.cpp
+++ b/app/src/main/cpp/Detail_AR_Main.cpp
@@ -21,41 +21,83 @@ void Detail_AR_Main(Mat& input, Mat& output){
 
     detect.Set_Image(img, false);    //  android 에서는 false로 설정한다.
 
+        // 루프 시작 지점 
 
-    vector<Point2i> corners;
-    vector<Point2i> balls_center;
-    vector<int> ball_color_ref;
-    vector<Point2i> wor_ball_cen;
+        vector<Point2i> corners;    // need clear
+        vector<Point2i> balls_center;  
+        vector<int> ball_color_ref;
+        vector<Point2i> wor_ball_cen;
+        int Corners_num;
+        int Balls_num;
+        int can_find_pose=-1;
+        bool find_ball_loc = false; 
+        static int situation = 1;
 
+        
+        // 상황1
 
+        if(situation == 1){
 
-    int Corners_failed = detect.Detect_Billiard_Corners(corners);
-    int Balls_failed = detect.Detect_Billirad_Balls(balls_center, ball_color_ref);
+            Corners_num = detect.Detect_Billiard_Corners(corners);
+            Balls_num = detect.Detect_Billirad_Balls(balls_center, ball_color_ref);
 
-    bool can_find_pose;
-        if((int)corners.size() == 4){  
-            can_find_pose = geo_proc.Cam_and_Balls_3D_Loc(corners, balls_center, ball_color_ref, wor_ball_cen);
+            // 제일 처음 모든 공의 위치를 파악하기 위함.
+            if(Corners_num == 4 && Balls_num >= 3){  // 4개의 코너, 4개의 공 모두가 감지 되어야함.
+                can_find_pose = geo_proc.Find_Balls_3D_Loc(corners, balls_center, ball_color_ref, wor_ball_cen, true);
             
-            // here, we need solution class    input: wor_ball_cen,  output: solution arrow.
+                //if can_fidnd_pose is true;  false -> continue;
 
-            geo_proc.Draw_Obj_on_Templete();   // draw circles under the balls and draw solution arrows on the table
+                // here, we need solution class --->>   input: wor_ball_cen,  output: solution arrow.
 
-            if(can_find_pose)
-                geo_proc.Draw_3D_Templete_on_Img(img);
+                geo_proc.Draw_Obj_on_Templete();   // draw circles under the balls and draw solution arrows on the table
+
+                if(can_find_pose != -1)
+                    geo_proc.Draw_3D_Templete_on_Img(img);
+            }
+
+            find_ball_loc = true;
         }
 
-        if(Balls_failed == 1)
+                      
+        // 상황2
+        //if find_ball_loc is true.
+
+        if(situation == 2){
+            Corners_num = detect.Detect_Billiard_Corners(corners);
+            Balls_num = detect.Detect_Billirad_Balls(balls_center, ball_color_ref);
+
+
+            if(Corners_num != -1 || Balls_num != -1 ){   // 공, 코너 둘중 하나라도 감지해야함.
+                can_find_pose = geo_proc.Find_Cam_Pos(corners, balls_center, ball_color_ref);
+
+                if(can_find_pose != -1){   // 포즈를 추정할 수 있다면
+                    geo_proc.Draw_3D_Templete_on_Img(img);
+                }
+            }
+
+            //geo_proc.Remove_Drawing_Info();
+        }
+
+
+
+        // for debugging
+
+        if(can_find_pose == 0)
+            geo_proc.Draw_Object(img);
+
+        if(Balls_num != 0)
             detect.Draw_Balls(img, balls_center, ball_color_ref);
 
-        if(Corners_failed != 0){
+        if(Corners_num != 0){
             detect.Draw_Corners(img, corners);
         }
 
+        if(find_ball_loc)
+            situation = 2;
 
 
     output = img; // for android
     detect.Clear_prev_frame_info();
-    geo_proc.Clear_prev_frame_info();
-    corners.clear();
+
 
 }

--- a/app/src/main/cpp/Detect_Table_Func.cpp
+++ b/app/src/main/cpp/Detect_Table_Func.cpp
@@ -33,16 +33,11 @@ void Detect_Billiard_Hole(Mat& input, Mat& output1, Mat& output2) // ** 영상�
     Mat element(H_Size,H_Size, CV_8U, Scalar(1));
     morphologyEx(border, morph, MORPH_CLOSE, element);  //
 
-
     Mat subtract = morph - border;
-
 
     Mat eroded;
     erode(subtract, eroded, Mat::ones(Size(3,3),CV_8UC1),Point(-1,-1),1);
     Mat edge = subtract- eroded;
-
-
-
 
     Mat subtract_roi = subtract(Rect(H_Size+1,H_Size+1, input.cols, input.rows));
     output1 = subtract_roi;

--- a/app/src/main/cpp/Detection.cpp
+++ b/app/src/main/cpp/Detection.cpp
@@ -26,10 +26,10 @@ int Detection::Detect_Billiard_Corners(vector<Point2i>& input_corners){
     input_corners = corners;
 
     int corner_size = corners.size();
-    if(corner_size <= 0 || corner_size >=5)
-        return 0;
+    if(corner_size < 0 || corner_size >=5)
+        return -1;
     else  
-        return 1;
+        return corner_size;
 }
 
 
@@ -41,15 +41,24 @@ int Detection::Detect_Billirad_Balls(vector<Point2i>& input_balls_center,  vecto
 
     Find_ball_center(ball_candidate, label_with_color, ball_colors,balls_center, ball_color_ref);
 
+    int c_t[3]={0,};
+    int s = ball_color_ref.size();
+    
+    if(s>4) // number of balls must be four.
+        ball_color_ref.resize(4);
+    
+    for(int i=0; i<s ; i++)
+        c_t[ball_color_ref[i]]++;
+     
+    if(!(c_t[0]<=2 && c_t[1] <=1 && c_t[2] <=1)) // Red Red Yellow White.
+        return -1;
 
     input_balls_center = balls_center;
     input_ball_color_ref = ball_color_ref;
 
     int ball_num = balls_center.size();
-    if(ball_num <= 0)
-        return 0;
-    else
-        return 1;
+
+    return ball_num;
 }
 
 

--- a/app/src/main/cpp/FInd_Cam_Pos.cpp
+++ b/app/src/main/cpp/FInd_Cam_Pos.cpp
@@ -1,0 +1,178 @@
+#include "Geo_Proc.hpp"
+#include "add_ons.h"
+#include "basic.h"
+
+
+int Geo_Proc::Find_Cam_Pos(vector<Point2i>& input_corners, vector<Point2i>& balls_center, vector<int>& ball_color_ref){
+    
+    // 코너의 위치가 정확할 확률이 높으므로 코너를 중심으로 분류해보자.
+    Mat in_rvec, in_tvec;
+    vector<Point2d> output_corners;
+
+    int ball_num = balls_center.size();
+    int corner_num = input_corners.size();
+    int can_find_pose = -1;
+    
+    if(corner_num == 4){  // can_find_pose == 0
+        // 공의 갯수와 상관 없이 4개의 코너를 이용해서 계산.
+        bool pose_flag = Cam_Pos_with_Four_Corners(input_corners, output_corners, in_rvec, in_tvec, true);
+        if(pose_flag){   // 카메라 pose를 구할수 있다면  포즈 정보 업데이트.
+            img_corners = output_corners;
+            can_find_pose = 0;
+        }
+
+        // 당구공의 위치 재계산 가능. 
+
+    }
+    else if(corner_num == 2){ // can_find_pose == 1
+        if(ball_num  < 2)   return -1;
+            // 계산 불가
+    }
+    else if(corner_num == 1){ // vcan_find_pose == 2
+        if(ball_num  < 3)   return -1;
+            // 계산 불가
+    }
+    else{ // ** 코너를 못 찾았더라도 공이 4개 있으면 괜찮다. can_find_pose == 3
+        if(ball_num != 4)   return -1;
+            // 계산 불가
+        
+    }
+
+
+    if(can_find_pose != -1){
+        rvec = in_rvec;
+        tvec = in_tvec;
+        return can_find_pose;
+    }
+
+    return -1;
+   
+    // 코너와 공의 조합이 주어지면 어떻게 시계방향으로 정렬을 할 수 있을까
+    // 시계방향 정렬에는 의미가 없을수도 있다.
+    
+    // 그리고 코너랑 다르게 공들의 위치가 매우 다양하기 때문에 오목한 모양이 나올수 있는데,
+    // 이것으로도 추정이 가능한지...??
+    
+    
+    
+    // 코너랑 공이랑 각각 따로 정렬 한다...??
+    
+    // 코너가 2개이면 뒤집어 가면서 해야한다....  매칭은 12 23 34 41 하면 되니께..!
+    // 코너쪽에서는 2개의 후보를 가지고 8번의 매칭을 해야 한다.
+    // reprojection 에러나 이전프레임과의 카메라 포즈 비교로 걸러내자!!
+    
+    // 공은 그대로 매칭하면 되긴하는데.. 빨간공이 문제이다.
+    // 빨간공이 2개라면 이 역시 뒤집어 가면서 해주어야 한다. 따로 만들어 주어야 하나?
+    
+    
+    
+    
+    // 코너가 1개면 정렬 필요없음..!! 매칭은 1 2 3 4 로 하면 되니께!!
+    // 역시 빨간공이 있는 경우가 문제가 될듯!!
+
+    // 공으로 카메라 pose를 추정할 때 공이 일직선에 있으면 안되는데 ...
+    
+
+}
+
+
+bool Geo_Proc::Cam_Pos_with_Four_Corners(vector<Point2i>& input_corners, vector<Point2d>& output_corners,
+Mat& in_rvec, Mat& in_tvec, bool comp_prev){
+    
+    vector<Point2d> temp_corners(4);
+    vector<Point2d> reproject_point(4);
+
+    Sort_Corners_Clockwise(input_corners);
+    for(int i=0; i<4 ;i++)
+        temp_corners[i] = static_cast<Point2d>(input_corners[3-i]);   // ** 반시계 방향으로 넣어야 z축이 천장을 향한다
+
+
+   // 코너가 시계방향으로 돌면서 reprojection 오차가 이 가장 작은 값을 취한다.
+   vector<pair<double, int>> dist_with_index(4);
+   vector<Point2d> temp[4];
+   Mat temp_rvec[4], temp_tvec[4];
+
+    for(int i=0; i<4 ; i++){
+    Clockwise_Permutation(temp_corners);
+    solvePnP(world_table_outside_corners, temp_corners, INTRINSIC, distCoeffs, temp_rvec[i], temp_tvec[i]);
+    projectPoints(world_table_outside_corners, temp_rvec[i], temp_tvec[i], INTRINSIC, distCoeffs, reproject_point);
+
+    double dist = double_vector_dist_sum(temp_corners, reproject_point);
+
+    dist_with_index[i].first = dist;
+    dist_with_index[i].second = i;
+
+    temp[i] = temp_corners;
+   }
+    
+    sort(dist_with_index.begin(), dist_with_index.end());
+
+    if(dist_with_index[0].first>200)   // 4개의 코너가 잘못되었을 가능성이 높다.
+        return false;
+
+    int id1 = dist_with_index[0].second;
+    int id2 = dist_with_index[1].second;
+
+    /*
+    for(int i=0; i<4 ;i++){
+       
+       cout<<"<"<<dist_with_index[i].first<<","<<dist_with_index[i].second<<">"<<endl;
+    }*/
+
+
+    if(comp_prev){   // 이전프레임 정보를 이용하여 id1과 id2 의 포즈중 하나를 선택한다.
+        // 이전프레임과 rvec 와 tvec 을 비교하여 적절한 코너와 rvec, tvec 을 반환한다.
+
+        Mat in_rvec1 = temp_rvec[id1];
+        Mat in_tvec1 = temp_tvec[id1];
+
+        Mat in_rvec2 = temp_rvec[id2];
+        Mat in_tvec2 = temp_tvec[id2];
+        
+        double dist_r1 = Dist_of_Rotation(rvec, in_rvec1);
+        double dist_r2 = Dist_of_Rotation(rvec, in_rvec2);
+        double dist_t1 = Dist_of_Translation(tvec, in_tvec1);
+        double dist_t2 = Dist_of_Translation(tvec, in_tvec2);
+
+        //cout<<dist_r1<<","<<dist_t1<<"  "<<dist_r2<<","<<dist_t2<<endl;
+
+        if(dist_r1+ dist_t1 > dist_r2 + dist_t2){
+            in_tvec = in_tvec2;
+            in_rvec = in_rvec2;
+            output_corners = temp[id2];
+        }
+        else{
+            in_tvec = in_tvec1;
+            in_rvec = in_rvec1;
+            output_corners = temp[id1];
+        }
+
+
+        //if() 이전프레임과 rvec과 tvec의 차이가 너무 크다면 구할 수 없다.
+    }
+    else  // index1 과 index2의 포즈 둘중 아무거나 반환.
+    {
+        output_corners = temp[id1];
+        in_rvec = temp_rvec[id1];
+        in_tvec = temp_tvec[id1];
+    }
+    
+
+    // for drawing
+    vector<Point3f> object_wor_pt(4);
+
+    object_wor_pt[0] = Point3f(0,0,0);
+    object_wor_pt[1] = Point3f(B_W,0,0);
+    object_wor_pt[2] = Point3f(B_W,B_H,0);
+    object_wor_pt[3] = Point3f(0,B_H,0);
+
+    projectPoints(object_wor_pt, in_rvec, in_tvec, INTRINSIC, distCoeffs, H_img_pts);
+    
+    H_wor_pts.resize(4);
+    H_wor_pts[0] = Point2f(0,0);
+    H_wor_pts[1] = Point2f(B_W,0);
+    H_wor_pts[2] = Point2f(B_W,B_H);
+    H_wor_pts[3] = Point2f(0,B_H);
+
+    return true;
+}

--- a/app/src/main/cpp/Geo_Proc.hpp
+++ b/app/src/main/cpp/Geo_Proc.hpp
@@ -9,12 +9,12 @@ class Geo_Proc
     
     Mat Ball_and_Sol_templete;
     vector<Point3d> world_table_outside_corners;
-    vector<Point2d> img_corners; // == corners
     vector<Point3i> wor_ball_loc;
     vector<int> world_ball_color_ref;
 
     Mat INTRINSIC;
     Mat distCoeffs;
+    
     Mat rvec, tvec;
 
     bool device_dir; // true: 가로 false: 세로
@@ -26,17 +26,31 @@ class Geo_Proc
     int B_W;
     int B_H;
 
+    // for drawing.
+    vector<Point2f> H_img_pts;
+    vector<Point2f> H_wor_pts;
+
+    //for debugging
+    vector<Point2d> img_corners;
+
+
 
     public:
     
     Geo_Proc(int f_len);
     void Set_Device_Dir(bool dir);
-    bool Cam_and_Balls_3D_Loc(vector<Point2i>& corners, vector<Point2i>& balls_center, vector<int>& ball_color_ref,
-    vector<Point2i>& wor_ball_cen);
+    bool Cam_Pos_with_Four_Corners(vector<Point2i>& input_corners, vector<Point2d>& output_corners,
+        Mat& in_rvec, Mat& in_tvec,  bool comp_prev);
+    int Find_Balls_3D_Loc(vector<Point2i>& corners, vector<Point2i>& balls_center, vector<int>& ball_color_ref,
+        vector<Point2i>& wor_ball_cen, bool update);
 
-    // for test
+    int Find_Cam_Pos(vector<Point2i>& input_corners, vector<Point2i>& balls_center, vector<int>& ball_color_ref);
+
     void Draw_Obj_on_Templete();
     void Draw_3D_Templete_on_Img(Mat& img);
+
+    // for test
+    void Draw_Object(Mat& img);
 
     //clear
     void Clear_prev_frame_info();

--- a/app/src/main/cpp/add_ons.cpp
+++ b/app/src/main/cpp/add_ons.cpp
@@ -10,9 +10,9 @@ double Vector_Degree(double x, double c_x, double y, double c_y){
 
             
         if(ratio >= 1.0)  // nan 문제 발생.
-            Rad=  acos( ratio - 0.001 );
+            Rad=  acos( ratio - 0.0001 );
         else if(ratio <= -1.0)
-            Rad=  acos( ratio + 0.001 );
+            Rad=  acos( ratio + 0.0001 );
         else
             Rad=  acos( dot_pro / dDen );
     
@@ -155,4 +155,35 @@ bool Point_Duplicate_check(int x, int y, vector<Point2i>& pts){
             flag = false;
     }
     return flag;
+}
+
+double Dist_of_Rotation(Mat& rvec1, Mat& rvec2)
+{
+    Mat R1, R2;
+    Rodrigues(rvec1, R1);
+    Rodrigues(rvec2, R2);
+
+    Mat R = R1*R2.t();
+    double diff = (trace(R)[0] - 1)/2;
+    double Rad;
+
+    if(diff >= 1.0)  // nan 문제 발생.
+        Rad=  acos( diff - 0.0001 );
+    else if(diff <= -1.0)
+        Rad=  acos( diff+ 0.0001 );
+    else
+        Rad=  acos( diff );
+
+    return Rad;
+
+}
+
+double Dist_of_Translation(Mat& tvec1, Mat& tvec2)
+{
+    double sum=0;
+    for(int i=0; i<3 ; i++){
+        double diff = (tvec1.ptr<double>(i)[0] -  tvec2.ptr<double>(i)[0]);
+        sum += diff*diff;
+    }
+    return sqrt(sum);
 }

--- a/app/src/main/cpp/add_ons.h
+++ b/app/src/main/cpp/add_ons.h
@@ -17,6 +17,8 @@ void Sort_Corners_Clockwise(vector<Point2i>& corners);
 int Get_Area(Point2i X, Point2i Y, Point2i Z);
 double double_vector_dist_sum(vector<Point2d>&a, vector<Point2d>&b);
 void Clockwise_Permutation(vector<Point2d>& pts);
+double Dist_of_Rotation(Mat& rvec1, Mat& rvec2);
+double Dist_of_Translation(Mat& tvec1, Mat& tvec2);
 
 
 #endif


### PR DESCRIPTION
1. Soften the AR using the distance of the previous camera pose.

There is no "key point" indicating the upper left corner.
So there was an ambiguous match between img_corner and wor_corner.

To maintain consistency in the matching, we use the minimum distance of translation and rotation compared to the previous frame.

2. Add a code that accepts a possible combination of ball colors.
There shouldn't be two yellow balls or two white balls.

3. Change "at operation" to "ptr operation" for speed.

4. Fix additional errors