### PR TITLE
Change Structure to utilize Solution function

### DIFF
--- a/app/src/main/cpp/Detail_AR_Main.cpp
+++ b/app/src/main/cpp/Detail_AR_Main.cpp
@@ -50,16 +50,17 @@ void Detail_AR_Main(Mat& input, Mat& output, int btn_index, int target_color, in
                 can_find_pose = geo_proc.Find_Balls_3D_Loc(corners, balls_center, ball_color_ref, wor_ball_cen, true);
 
                 geo_proc.Draw_Obj_on_Templete();   // draw circles under the balls and draw solution arrows on the table
-                Mat templete = geo_proc.GetTemplete();
+                Mat templete = geo_proc.GetTemplate();
 //                templete.copyTo(saveMat);
                 c_situation = 2;  // 4개의 공, 4개의 코너 모두 인식된 상황. "인식버튼을 눌러주세요"
 
                 if(btn_index == 1)
                 {
                     BilliardSollution(templete, wor_ball_cen, ball_color_ref, target_color, btn_index);
+                    geo_proc.SaveTemplate(templete);  // you must save the template.
 
                     if(can_find_pose != -1){
-                        geo_proc.Draw_3D_Templete_on_Img(img);
+                        geo_proc.Draw_3D_Template_on_Img(img);
                         find_ball_loc = true;
                     }
                 }
@@ -81,11 +82,11 @@ void Detail_AR_Main(Mat& input, Mat& output, int btn_index, int target_color, in
                 can_find_pose = geo_proc.Find_Cam_Pos(corners, balls_center, ball_color_ref);
 
                 if(can_find_pose != -1){   // 포즈를 추정할 수 있다면 물체를 증강시킨다.
-                    geo_proc.Draw_3D_Templete_on_Img(img);
+                    geo_proc.Draw_3D_Template_on_Img(img);
                     e_cum=0;
                 }
                 else if(e_cum < 3){
-                    geo_proc.Draw_3D_Templete_on_Img(img);
+                    geo_proc.Draw_3D_Template_on_Img(img);
                     e_cum++;
                 }
             }

--- a/app/src/main/cpp/Geo_Proc.cpp
+++ b/app/src/main/cpp/Geo_Proc.cpp
@@ -147,8 +147,8 @@ vector<Point2i>& wor_ball_cen, bool update)
 }
 
 
-void Geo_Proc::Draw_Obj_on_Templete(){
-    Ball_and_Sol_templete = Mat(B_H,B_W, CV_8UC3, Scalar(0,0,0));   // for drawing
+void Geo_Proc::Draw_Obj_on_Template(){
+    Ball_templete = Mat(B_H,B_W, CV_8UC3, Scalar(0,0,0));   // for drawing
                     
     for(int i=0; i<4 ; i++){
         Scalar color;
@@ -162,7 +162,7 @@ void Geo_Proc::Draw_Obj_on_Templete(){
         else
             continue;
                         
-        circle(Ball_and_Sol_templete, Point(wor_ball_loc[i].x, wor_ball_loc[i].y), ball_rad, color, 8, 8, 0);
+        circle(Ball_templete, Point(wor_ball_loc[i].x, wor_ball_loc[i].y), ball_rad, color, 8, 8, 0);
     }
                    
 }
@@ -253,11 +253,15 @@ bool Geo_Proc::Error_Comparison_with_Prev_Frame(Mat& in_rvec, Mat& in_tvec, doub
 
 }
 
-Mat& Geo_Proc::GetTemplete(void){
-    return Ball_and_Sol_templete;
+Mat Geo_Proc::GetTemplate(void){
+    return Ball_templete.clone();
 }
 
-void Geo_Proc::Draw_3D_Templete_on_Img(Mat& img){
+void Geo_Proc::SaveTemplate(Mat& templete){
+    Ball_and_Sol_templete = templete;
+}
+
+void Geo_Proc::Draw_3D_Template_on_Img(Mat& img){
 
     // *****당구공아래에 원 표시*****
     

--- a/app/src/main/cpp/Geo_Proc.hpp
+++ b/app/src/main/cpp/Geo_Proc.hpp
@@ -6,6 +6,7 @@
 class Geo_Proc
 {
     private:
+    Mat Ball_templete;
     Mat Ball_and_Sol_templete;
     vector<Point3d> world_table_outside_corners;
     vector<Point3f> world_table_inside_corners_f;
@@ -62,9 +63,10 @@ class Geo_Proc
     void Distance_from_Prev_Frame(Mat& rvec_, Mat& tvec_, double& distance);
     int Distance_from_Error_Frame(Mat& rvec_, Mat& tvec_);
         
-    Mat& GetTemplete(void);
-    void Draw_Obj_on_Templete();
-    void Draw_3D_Templete_on_Img(Mat& img);
+    Mat GetTemplate(void);
+    void SaveTemplate(Mat& templete);
+    void Draw_Obj_on_Template();
+    void Draw_3D_Template_on_Img(Mat& img);
 
     // for test
     void Draw_Object(Mat& img);


### PR DESCRIPTION
There are two member variable in Geo_Proc class.
    Mat Ball_templete;
    Mat Ball_and_Sol_templete;

And There are three functions you can use.
    Mat GetTemplate(void);
    void SaveTemplate(Mat& templete);

"Ball_templete" has just 4 circles that will be drawn under the billiard balls.
(We can change this variable by calling the function "geo_proc.Draw_Obj_on_Template()".
But you don't care about it. it is just called ones at situation 1)

You need to pay a attention to "Ball_and_Sol_templete" variable.
If you call GetTemplate(void) function, you can get "Ball_templete" as a deep copy.

So,
	Mat templete = geo_proc.GetTemplate();
You can draw your solution arrow on local variable "Mat templete"

And you have to call "SaveTemplate(Mat& templete);"  to save "Mat templete".
SaveTemplate(Mat& templete) can save "Mat templete" to "Mat Ball_and_Sol_templete"

Later, geo_proc.Draw_3D_Template_on_Img(img); will draw final our solution arrows!

To abstract,
1. Get template ( from     Mat Ball_templete;
2. draw your solution on template
3. Save template (to      Mat Ball_and_Sol_templete; )